### PR TITLE
Fail if the actual array has items but the expected is empty

### DIFF
--- a/lib/chai-subset.js
+++ b/lib/chai-subset.js
@@ -37,11 +37,15 @@ function compare(expected, actual) {
 			return false;
 		}
 		var aa = Array.prototype.slice.call(actual);
-		return expected.every(function (exp) {
-			return aa.some(function (act) {
-				return compare(exp, act);
-			});
-		});
+                if (!expected.length) {
+                  return Array.isArray(aa) && !aa.length;
+                } else {
+                  return expected.every(function (exp) {
+                    return aa.some(function (act) {
+                      return compare(exp, act);
+                    });
+                  });
+                }
 	}
 
 	return Object.keys(expected).every(function (key) {

--- a/test/unit/chai-subset.spec.js
+++ b/test/unit/chai-subset.spec.js
@@ -140,3 +140,21 @@ describe('assert style of test', function () {
 		assert.containSubset({a: 1, b: 2}, {a: 1});
 	});
 });
+
+describe('object containing an array', function () {
+  it('should fail if expected is filled but actual is empty', function () {
+    expect({ anArray: ['1'] }).to.not.containSubset({ anArray: [] });
+  })
+
+  it('should fail if actual is empty but expected is filled', function () {
+    expect({ anArray: [] }).to.not.containSubset({ anArray: ['1'] });
+  })
+
+  it('should not fail if array contains the same elements', function () {
+    expect({ anArray: ['1'] }).to.containSubset({ anArray: ['1'] });
+  });
+
+  it('should not fail if both arrays are empty', function () {
+    expect({ anArray: [] }).to.containSubset({ anArray: [] });
+  });
+})


### PR DESCRIPTION
**Not ready to merge yet, as this makes the circular object test to fail.**

```javascript
it('should fail if expected is filled but actual is empty', function () {
   expect({ anArray: ['1'] }).to.not.containSubset({ anArray: [] });
})
````

The above (new) test was failing, so I tried to fix it (assuming it's a bug).

This makes the circular object test to fail. Before trying to fix that I'd like to know if this logic is ok, and any comments you might have regarding the circular object test failing (maybe it can be written on a different way, or maybe this new logic I'm trying to add is just wrong).