### PR TITLE
Specify exactly which files to package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.idea
-node_modules
-test
-.gitignore
-.jshintignore
-.jshintrc

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "mocha": "^2.2.1",
     "mocha-eslint": "^2.0.0",
     "mocha-jscs": "^4.0.0"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
Currently, chai-subset packages the following files up when chai-subset is versioned:
```
  8B .eslintignore
505B .eslintrc
107B .jscsrc
 59B .npmignore
112B .travis.yml
1.0K LICENSE
1.7K README.md
204B coverage
102B lib
2.2K package.json
```

Only `package.json`, `README.md`, `LICENSE`, and `lib` are really needed. Specifying the `"files"` key in `package.json` will limit these files, removing the need for `.npmignore` as well.

https://docs.npmjs.com/files/package.json#files