### PR TITLE
Introduce strict equality check in compare()

### DIFF
--- a/lib/chai-subset.js
+++ b/lib/chai-subset.js
@@ -32,6 +32,9 @@
 		};
 
 		function compare(expected, actual) {
+			if (expected === actual) {
+				return true;
+			}
 			if (typeof(actual) !== typeof(expected)) {
 				return false;
 			}


### PR DESCRIPTION
If two objects are the same, then inherently they're subsets of each other. This also fixes a bug I've run into with testing recursive data structures.