### PR TITLE
Adding a compare function to be used in expected object template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ expect(obj).to.containSubset({
 		}
 	}
 });
-//or with 'not'
+
+// or using a compare function
+expect(obj).containSubset({
+	a: (expectedValue) => expectedValue,
+	c: (expectedValue) => expectedValue === 'd'
+})
+
+// or with 'not'
 expect(obj).to.not.containSubset({
 	g: 'whatever'
 });

--- a/lib/chai-subset.js
+++ b/lib/chai-subset.js
@@ -71,6 +71,9 @@
 				if (typeof(eo) === 'object' && eo !== null && ao !== null) {
 					return compare(eo, ao);
 				}
+				if (typeof(eo) === 'function') {
+					return eo(ao);
+				}
 				return ao === eo;
 			});
 		}

--- a/test/unit/chai-subset.spec.js
+++ b/test/unit/chai-subset.spec.js
@@ -126,6 +126,20 @@ describe('circular objects', function() {
 	});
 });
 
+describe('object with compare function', function() {
+	it('should pass when function returns true', function () {
+		expect({a: 5}).to.containSubset({a: a => a});
+	});
+
+	it('should fail when function returns false', function () {
+		expect({a: 5}).to.not.containSubset({a: a => !a});
+	});
+
+	it('should pass for function with no arguments', function () {
+		expect({a: 5}).to.containSubset({a: () => true});
+	});
+});
+
 describe('comparison of non objects', function () {
 	it('should fail if actual subset is null', function () {
 		expect(null).to.not.containSubset({a: 1});


### PR DESCRIPTION
The idea of this PR is to add a possibility of using a compare function inside the expected object. This allows not only checking for static values, but also adding more sophisticated checks like check for being not null, check for been defined etc.

Here is an example. I store an object and then additionally check that `id`, `createdAt` and `updatedAt` properties are present in the object. The check would not be possible without the compare function because returned values are expected to be different between different test runs.

```
        it('should store object', async function () {
            const publisherData = {
                name: 'publisher',
                descr: 'description',
                urls: { homepage: 'http://homepage' }
            }
            const publisher = await repository.findOrCreatePublisher(publisherData)
            expect(publisher).containSubset({
                ...publisherData,
                id: id => id,
                createdAt: createdAt => createdAt,
                updatedAt: updatedAt => updatedAt
            })
        })
```

This might also solve #64.