### PR TITLE
fix: use cjs only for export and add types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var obj = {
 		}
 	}
 };
-	
+
 expect(obj).to.containSubset({
 	a: 'b',
 	e: {
@@ -59,7 +59,7 @@ var list = [{a: 'a', b: 'b'}, {v: 'f', d: {z: 'g'}}];
 list.should.containSubset([{a:'a'}]); //Assertion error is not thrown
 list.should.containSubset([{a:'a',  b: 'b'}]); //Assertion error is not thrown
 
-list.should.containSubset([{a:'a', b: 'bd'}]); 
+list.should.containSubset([{a:'a', b: 'bd'}]);
 /*throws
 AssertionError: expected
 [
@@ -74,12 +74,12 @@ AssertionError: expected
         }
     }
 ]
-to contain subset 
+to contain subset
 [ { a: 'a', b: 'bd' } ]
 */
 ```
 
 and with `assert` interface
 ```js
-assert.containSubset({a: 1, b: 2}, {a: 1});
+assert.containSubset({ a: 1, b: 2}, {a: 1});
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+
+// Type definitions for chai-subset 1.3
+// Project: https://github.com/debitoor/chai-subset
+// Definitions by: Sam Noedel <https://github.com/delta62>, Andrew Brown <https://github.com/AGBrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/// <reference types="chai" />
+
+declare global {
+  namespace Chai {
+      interface Assertion {
+          containSubset(expected: any): Assertion;
+      }
+      interface Assert {
+          containSubset(val: any, exp: any, msg?: string): void;
+      }
+  }
+}
+
+declare const chaiSubset: Chai.ChaiPlugin;
+export = chaiSubset;

--- a/lib/chai-subset.js
+++ b/lib/chai-subset.js
@@ -1,83 +1,72 @@
-(function() {
-	(function(chaiSubset) {
-		if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-			return module.exports = chaiSubset;
-		} else if (typeof define === 'function' && define.amd) {
-			return define(function() {
-				return chaiSubset;
-			});
-		} else {
-			return chai.use(chaiSubset);
-		}
-	})(function(chai, utils) {
-		var Assertion = chai.Assertion;
-		var assertionPrototype = Assertion.prototype;
 
-		Assertion.addMethod('containSubset', function (expected) {
-			var actual = utils.flag(this, 'object');
-			var showDiff = chai.config.showDiff;
+function chaiSubset(chai, utils) {
+	var Assertion = chai.Assertion;
+	var assertionPrototype = Assertion.prototype;
 
-			assertionPrototype.assert.call(this,
-				compare(expected, actual),
-				'expected #{act} to contain subset #{exp}',
-				'expected #{act} to not contain subset #{exp}',
-				expected,
-				actual,
-				showDiff
-			);
-		});
+	Assertion.addMethod('containSubset', function(expected) {
+		var actual = utils.flag(this, 'object');
+		var showDiff = chai.config.showDiff;
 
-		chai.assert.containSubset = function(val, exp, msg) {
-			new chai.Assertion(val, msg).to.be.containSubset(exp);
-		};
-
-		function compare(expected, actual) {
-			if (expected === actual) {
-				return true;
-			}
-			if (typeof(actual) !== typeof(expected)) {
-				return false;
-			}
-			if (typeof(expected) !== 'object' || expected === null) {
-				return expected === actual;
-			}
-			if (!!expected && !actual) {
-				return false;
-			}
-
-			if (Array.isArray(expected)) {
-				if (typeof(actual.length) !== 'number') {
-					return false;
-				}
-				var aa = Array.prototype.slice.call(actual);
-				return expected.every(function (exp) {
-					return aa.some(function (act) {
-						return compare(exp, act);
-					});
-				});
-			}
-
-			if (expected instanceof Date) {
-				if (actual instanceof Date) {
-					return expected.getTime() === actual.getTime();
-				} else {
-					return false;
-				}
-			}
-
-			return Object.keys(expected).every(function (key) {
-				var eo = expected[key];
-				var ao = actual[key];
-				if (typeof(eo) === 'object' && eo !== null && ao !== null) {
-					return compare(eo, ao);
-				}
-				if (typeof(eo) === 'function') {
-					return eo(ao);
-				}
-				return ao === eo;
-			});
-		}
+		assertionPrototype.assert.call(this,
+			compare(expected, actual),
+			'expected #{act} to contain subset #{exp}',
+			'expected #{act} to not contain subset #{exp}',
+			expected,
+			actual,
+			showDiff
+		);
 	});
 
-}).call(this);
+	chai.assert.containSubset = function(val, exp, msg) {
+		new chai.Assertion(val, msg).to.be.containSubset(exp);
+	};
 
+	function compare(expected, actual) {
+		if (expected === actual) {
+			return true;
+		}
+		if (typeof(actual) !== typeof(expected)) {
+			return false;
+		}
+		if (typeof(expected) !== 'object' || expected === null) {
+			return expected === actual;
+		}
+		if (!!expected && !actual) {
+			return false;
+		}
+
+		if (Array.isArray(expected)) {
+			if (typeof(actual.length) !== 'number') {
+				return false;
+			}
+			var aa = Array.prototype.slice.call(actual);
+			return expected.every(function(exp) {
+				return aa.some(function(act) {
+					return compare(exp, act);
+				});
+			});
+		}
+
+		if (expected instanceof Date) {
+			if (actual instanceof Date) {
+				return expected.getTime() === actual.getTime();
+			} else {
+				return false;
+			}
+		}
+
+		return Object.keys(expected).every(function(key) {
+			var eo = expected[key];
+			var ao = actual[key];
+			if (typeof(eo) === 'object' && eo !== null && ao !== null) {
+				return compare(eo, ao);
+			}
+			if (typeof(eo) === 'function') {
+				return eo(ao);
+			}
+			return ao === eo;
+		});
+	}
+}
+
+module.exports = chaiSubset;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.0",
   "description": "Object properties matcher for Chai",
   "main": "lib/chai-subset.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "istanbul cover _mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
@@ -36,12 +37,13 @@
   },
   "homepage": "https://github.com/debitoor/chai-subset",
   "devDependencies": {
-    "@debitoor/eslint-config-debitoor": "1.2.0",
-    "chai": "3.5.0",
-    "coveralls": "2.11.16",
+    "@debitoor/eslint-config-debitoor": "^3.1.0",
+    "@types/chai": "^4.2.17",
+    "chai": "^4.3.4",
+    "coveralls": "^3.1.0",
     "istanbul": "0.4.5",
-    "mocha": "3.2.0",
-    "mocha-eslint": "3.0.1"
+    "mocha": "^8.3.2",
+    "mocha-eslint": "^7.0.0"
   },
   "files": [
     "lib"

--- a/test/unit/chai-subset.spec.js
+++ b/test/unit/chai-subset.spec.js
@@ -81,7 +81,7 @@ describe('complex object', function() {
 		});
 	});
 
-	it('should fail if comparing when comparing objects to dates', function () {
+	it('should fail if comparing when comparing objects to dates', function() {
 		expect(testedObject).to.not.containSubset({
 			e: new Date()
 		});
@@ -102,11 +102,11 @@ describe('circular objects', function() {
 	it('should contain subdocument', function() {
 		expect(object).to.containSubset({
 			arr: [
-				{arr: []},
-				{arr: []},
+				{ arr: [] },
+				{ arr: [] },
 				[
-					{arr: []},
-					{arr: []}
+					{ arr: [] },
+					{ arr: [] }
 				]
 			]
 		});
@@ -115,11 +115,11 @@ describe('circular objects', function() {
 	it('should not contain similar object', function() {
 		expect(object).to.not.containSubset({
 			arr: [
-				{arr: ['just random field']},
-				{arr: []},
+				{ arr: ['just random field'] },
+				{ arr: [] },
 				[
-					{arr: []},
-					{arr: []}
+					{ arr: [] },
+					{ arr: [] }
 				]
 			]
 		});
@@ -127,37 +127,37 @@ describe('circular objects', function() {
 });
 
 describe('object with compare function', function() {
-	it('should pass when function returns true', function () {
-		expect({a: 5}).to.containSubset({a: a => a});
+	it('should pass when function returns true', function() {
+		expect({ a: 5 }).to.containSubset({ a: a => a });
 	});
 
-	it('should fail when function returns false', function () {
-		expect({a: 5}).to.not.containSubset({a: a => !a});
+	it('should fail when function returns false', function() {
+		expect({ a: 5 }).to.not.containSubset({ a: a => !a });
 	});
 
-	it('should pass for function with no arguments', function () {
-		expect({a: 5}).to.containSubset({a: () => true});
+	it('should pass for function with no arguments', function() {
+		expect({ a: 5 }).to.containSubset({ a: () => true });
 	});
 });
 
-describe('comparison of non objects', function () {
-	it('should fail if actual subset is null', function () {
-		expect(null).to.not.containSubset({a: 1});
+describe('comparison of non objects', function() {
+	it('should fail if actual subset is null', function() {
+		expect(null).to.not.containSubset({ a: 1 });
 	});
 
-	it('should fail if expected subset is not a object', function () {
-		expect({a: 1}).to.not.containSubset(null);
+	it('should fail if expected subset is not a object', function() {
+		expect({ a: 1 }).to.not.containSubset(null);
 	});
 
-	it('should not fail for same non-object (string) variables', function () {
+	it('should not fail for same non-object (string) variables', function() {
 		expect('string').to.containSubset('string');
 	});
 });
 
-describe('assert style of test', function () {
-	it('should find subset', function () {
+describe('assert style of test', function() {
+	it('should find subset', function() {
 		var assert = require('chai').assert;
-		assert.containSubset({a: 1, b: 2}, {a: 1});
+		assert.containSubset({ a: 1, b: 2 }, { a: 1 });
 	});
 });
 
@@ -167,7 +167,7 @@ describe('comparison of dates', function() {
 	});
 
 	it('should pass for the same date if nested', function() {
-		expect({a: new Date('2015-11-30')}).to.containSubset({a: new Date('2015-11-30')});
+		expect({ a: new Date('2015-11-30') }).to.containSubset({ a: new Date('2015-11-30') });
 	});
 
 	it('should fail for a different date', function() {
@@ -175,7 +175,7 @@ describe('comparison of dates', function() {
 	});
 
 	it('should fail for a different date if nested', function() {
-		expect({a: new Date('2015-11-30')}).to.not.containSubset({a: new Date('2012-02-22')});
+		expect({ a: new Date('2015-11-30') }).to.not.containSubset({ a: new Date('2012-02-22') });
 	});
 
 	it('should fail for invalid expected date', function() {
@@ -194,7 +194,7 @@ describe('cyclic objects', () => {
 			children: [child],
 		};
 		child.parent = parent;
-	
+
 		const myObject = {
 			a: 1,
 			b: 'two',


### PR DESCRIPTION
Updates this module to use the [latest pattern for chai plugins](https://www.chaijs.com/guide/plugins/)
- the previous pattern causes problems with modern bundlers as
it tries to support cjs, amd and script tags in one file.

Also adds the types from the DefinitleyTyped project so users don't
have to include extra deps to use this module.

Also, also upgrades all deps and fixes the new linting errors.